### PR TITLE
Use optimized empty array throughout runtime

### DIFF
--- a/src/fsharp/FSharp.Core/Query.fs
+++ b/src/fsharp/FSharp.Core/Query.fs
@@ -148,7 +148,7 @@ type QueryBuilder() =
             acc <- plus acc (selector e.Current)
             count <- count + 1
         if count = 0 then 
-            invalidOp "source" (System.Linq.Enumerable.Average ([| |]: int[])) // raise the same error as LINQ
+            invalidOp "source" (System.Linq.Enumerable.Average (Array.empty: int[])) // raise the same error as LINQ
         LanguagePrimitives.DivideByInt< (^U) > acc count
 
     member inline __.SumBy< 'T, 'Q, ^Value 

--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -77,14 +77,9 @@ namespace Microsoft.FSharp.Collections
             if array.Length = 0 then invalidArg "array" (SR.GetString(SR.notEnoughElements))
             let len = array.Length - 1
             Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 1 len array
-    
-        [<AbstractClass; Sealed>]
-        type internal EmptyStorage<'T>() =
-            static let empty = (zeroCreate 0 : 'T[])
-            static member Empty = empty
 
         [<CompiledName("Empty")>]
-        let empty<'T> = EmptyStorage<'T>.Empty
+        let empty<'T> = Microsoft.FSharp.Primitives.Basics.Array.EmptyStorage<'T>.Empty
 
         [<CodeAnalysis.SuppressMessage("Microsoft.Naming","CA1704:IdentifiersShouldBeSpelledCorrectly")>]
         [<CompiledName("CopyTo")>]
@@ -147,10 +142,10 @@ namespace Microsoft.FSharp.Collections
             if array.Length < index then raise <| System.InvalidOperationException (SR.GetString(SR.notEnoughElements))
             if index = 0 then
                 let right = Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 0 array.Length array
-                [||],right
+                empty,right
             elif index = array.Length then
                 let left = Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 0 array.Length array
-                left,[||] else
+                left,empty else
 
             let res1 = Microsoft.FSharp.Primitives.Basics.Array.subUnchecked 0 index array
             let res2 = Microsoft.FSharp.Primitives.Basics.Array.subUnchecked index (array.Length-index) array
@@ -525,7 +520,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "array" array
             if count > array.Length then invalidArg "count" (SR.GetString(SR.outOfRange))
             if count = array.Length then
-                [| |]
+                empty
             else
                 let count = max count 0
                 Microsoft.FSharp.Primitives.Basics.Array.subUnchecked count (array.Length - count) array
@@ -538,7 +533,7 @@ namespace Microsoft.FSharp.Collections
             while i < len && p array.[i] do i <- i + 1
 
             match len - i with
-            | 0 -> [| |]
+            | 0 -> empty
             | resLen ->
                 Microsoft.FSharp.Primitives.Basics.Array.subUnchecked i resLen array
 
@@ -568,7 +563,7 @@ namespace Microsoft.FSharp.Collections
             if windowSize <= 0 then invalidArg "windowSize" (SR.GetString(SR.inputMustBePositive))
             let len = array.Length
             if windowSize > len then
-                [| |]
+                empty
             else
                 let res = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked (len - windowSize + 1) : 'T[][]
                 for i = 0 to len - windowSize do
@@ -581,7 +576,7 @@ namespace Microsoft.FSharp.Collections
             if chunkSize <= 0 then invalidArg "chunkSize" (SR.GetString(SR.inputMustBePositive))
             let len = array.Length
             if len = 0 then
-                [| |]
+                empty
             else if chunkSize > len then
                 [| copy array |]
             else
@@ -751,7 +746,7 @@ namespace Microsoft.FSharp.Collections
         [<CompiledName("Pairwise")>]
         let pairwise (array: 'T[]) =
             checkNonNull "array" array
-            if array.Length < 2 then [||] else
+            if array.Length < 2 then empty else
             init (array.Length-1) (fun i -> array.[i],array.[i+1])
 
         [<CompiledName("Reduce")>]

--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -331,7 +331,7 @@ namespace Microsoft.FSharp.Control
     /// We use our own internal implementation of queues to avoid a dependency on System.dll
     type Queue<'T>() =  //: IEnumerable<T>, ICollection, IEnumerable
     
-        let mutable array = [| |]
+        let mutable array = Array.empty
         let mutable head = 0
         let mutable size = 0
         let mutable tail = 0
@@ -1408,7 +1408,7 @@ namespace Microsoft.FSharp.Control
                 match result with
                 | Some r -> r
                 | None ->
-                if tasks.Length = 0 then args.cont [| |] else  // must not be in a 'protect' if we call cont explicitly; if cont throws, it should unwind the stack, preserving Dev10 behavior
+                if tasks.Length = 0 then args.cont Array.empty else  // must not be in a 'protect' if we call cont explicitly; if cont throws, it should unwind the stack, preserving Dev10 behavior
                 protectedPrimitiveCore args (fun args ->
                     let ({ aux = aux } as args) = delimitSyncContext args  // manually resync
                     let count = ref tasks.Length

--- a/src/fsharp/FSharp.Core/local.fs
+++ b/src/fsharp/FSharp.Core/local.fs
@@ -750,6 +750,11 @@ module internal Array =
     let inline zeroCreateUnchecked (count:int) = 
         (# "newarr !0" type ('T) count : 'T array #)
 
+    [<AbstractClass; Sealed>]
+    type internal EmptyStorage<'T>() =
+        static let empty : 'T[] = zeroCreateUnchecked 0
+        static member Empty = empty
+        
     let inline init (count:int) (f: int -> 'T) = 
         if count < 0 then invalidArg "count" LanguagePrimitives.ErrorStrings.InputMustBeNonNegativeString
         let arr = (zeroCreateUnchecked count : 'T array)  
@@ -801,7 +806,7 @@ module internal Array =
 
     let mapFold f acc (array : _[]) =
         match array.Length with
-        | 0 -> [| |], acc
+        | 0 -> EmptyStorage.Empty, acc
         | len ->
             let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
             let mutable acc = acc
@@ -814,7 +819,7 @@ module internal Array =
 
     let mapFoldBack f (array : _[]) acc =
         match array.Length with
-        | 0 -> [| |], acc
+        | 0 -> EmptyStorage.Empty, acc
         | len ->
             let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
             let mutable acc = acc
@@ -925,7 +930,7 @@ module internal Array =
     let splitInto count (array : 'T[]) =
         let len = array.Length
         if len = 0 then
-            [| |]
+            EmptyStorage.Empty
         else
             let count = min count len
             let res = zeroCreateUnchecked count : 'T[][]

--- a/src/fsharp/FSharp.Core/local.fsi
+++ b/src/fsharp/FSharp.Core/local.fsi
@@ -43,6 +43,10 @@ module internal List =
 module internal Array =
     // The input parameter should be checked by callers if necessary
     val inline zeroCreateUnchecked : int -> 'T[]
+    
+    [<AbstractClass; Sealed>]
+    type internal EmptyStorage<'T> =
+        static member Empty : 'T []
 
     val inline init : int -> (int -> 'T) -> 'T[]
 

--- a/src/fsharp/FSharp.Core/option.fs
+++ b/src/fsharp/FSharp.Core/option.fs
@@ -48,7 +48,7 @@ namespace Microsoft.FSharp.Core
         let filter f inp = match inp with None -> None | Some x -> if f x then Some x else None
 
         [<CompiledName("ToArray")>]
-        let toArray option = match option with  None -> [| |] | Some x -> [| x |]
+        let toArray option = match option with  None -> Microsoft.FSharp.Primitives.Basics.Array.EmptyStorage.Empty | Some x -> [| x |]
 
         [<CompiledName("ToList")>]
         let toList option = match option with  None -> [ ] | Some x -> [ x ]

--- a/src/fsharp/FSharp.Core/reflect.fs
+++ b/src/fsharp/FSharp.Core/reflect.fs
@@ -120,7 +120,7 @@ module ReflectionAdapters =
         member this.GetGenericArguments() = 
             if this.IsGenericTypeDefinition then this.GetTypeInfo().GenericTypeParameters
             elif this.IsGenericType then this.GenericTypeArguments
-            else [||]
+            else Array.empty
         member this.BaseType = this.GetTypeInfo().BaseType
         member this.GetConstructor(parameterTypes : Type[]) = 
             this.GetTypeInfo().DeclaredConstructors
@@ -482,19 +482,19 @@ module internal Impl =
     let fieldsPropsOfUnionCase(typ:Type, tag:int, bindingFlags) =
         if isOptionType typ then 
             match tag with 
-            | 0 (* None *) -> getInstancePropertyInfos (typ,[| |],bindingFlags) 
+            | 0 (* None *) -> getInstancePropertyInfos (typ,Array.empty,bindingFlags) 
             | 1 (* Some *) -> getInstancePropertyInfos (typ,[| "Value" |] ,bindingFlags) 
             | _ -> failwith "fieldsPropsOfUnionCase"
         elif isListType typ then 
             match tag with 
-            | 0 (* Nil *)  -> getInstancePropertyInfos (typ,[| |],bindingFlags) 
+            | 0 (* Nil *)  -> getInstancePropertyInfos (typ,Array.empty,bindingFlags) 
             | 1 (* Cons *) -> getInstancePropertyInfos (typ,[| "Head"; "Tail" |],bindingFlags) 
             | _ -> failwith "fieldsPropsOfUnionCase"
         else
             // Lookup the type holding the fields for the union case
             let caseTyp = getUnionCaseTyp (typ, tag, bindingFlags)
             match caseTyp with 
-            | null ->  [| |]
+            | null ->  Array.empty
             | _ ->  caseTyp.GetProperties(instancePropertyFlags ||| bindingFlags) 
                     |> Array.filter isFieldProperty
                     |> Array.filter (fun prop -> variantNumberOfMember prop = tag)
@@ -565,7 +565,7 @@ module internal Impl =
                 invalidArg "unionType" (SR.GetString1(SR.privateUnionType, unionType.FullName))
             else
                 invalidArg "unionType" (SR.GetString1(SR.notAUnionType, unionType.FullName))
-    let emptyObjArray : obj[] = [| |]
+    let emptyObjArray : obj[] = Array.empty
 
     //-----------------------------------------------------------------
     // TUPLE DECOMPILATION


### PR DESCRIPTION
Suggestion on how to incorporate optimized `empty`, even in the runtime.
